### PR TITLE
add check for tiles

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,3 +16,11 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v7
       - run: uv run pytest 
+  check-generate-tiles:
+    # TODO: Replace with ubuntu-latest when imagemagick7 is available
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: brew install imagemagick
+      - run: sh ./generate_tiles.sh ./tiles.csv tiles
+      - run: git diff --exit-code tiles


### PR DESCRIPTION
Verifies that changes that would impact tiles are run as a check.

Note: This uses the macos runner as using `act` with the ubuntu runner led to a format error on exec of the magick binary.

```
runs-on: ubuntu-latest
steps:
  - uses: actions/checkout@v6
  # TODO: Remove this step after libfuse2 is correctly installed from setup-imagemagick
  - run: apt-get update
  - uses: mfinelli/setup-imagemagick@v7
  - run: apt-get install -y bc
```